### PR TITLE
Fix npm provenance publish and bump to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "investec-card-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "investec-card-cli",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investec-card-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "bin/index.js",
   "bin": {
     "card-emu": "./bin/index.js"
@@ -26,6 +26,10 @@
   "author": "Devin Pearson",
   "license": "MIT",
   "description": "An emulator for the Programmable Card Code Lamda function",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devinpearson/card-code-cli.git"
+  },
   "dependencies": {
     "chalk": "^4.1.2",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
- Add `repository.url` so npm trusted publishing / Sigstore provenance can verify the package against this GitHub repo
- Bump version to 1.2.1 (1.2.0 publish failed with E422)

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, tag `v1.2.1` and confirm the publish workflow succeeds on npm


Made with [Cursor](https://cursor.com)